### PR TITLE
change to database schema to allow association between users and builds

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -11,3 +11,5 @@ npx sequelize model:generate --name BuildAndShelf --attributes buildStatus:strin
 npx sequelize model:generate --name BuildAndTheme --attributes buildId:integer,themeId:integer
 
 npx dotenv sequelize db:migrate
+
+npx dotenv sequelize db:migrate:undo:all

--- a/db/migrations/20220509222001-create-build.js
+++ b/db/migrations/20220509222001-create-build.js
@@ -23,6 +23,14 @@ module.exports = {
       pieceCount: {
         type: Sequelize.INTEGER
       },
+      userId: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: "Users",
+          key: "id"
+        }
+      },
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE

--- a/db/models/build.js
+++ b/db/models/build.js
@@ -10,7 +10,8 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false
     },
     legoItemNumber: DataTypes.INTEGER,
-    pieceCount: DataTypes.INTEGER
+    pieceCount: DataTypes.INTEGER,
+    userId: DataTypes.INTEGER
   }, {});
   Build.associate = function(models) {
     // associations can be defined here

--- a/db/models/build.js
+++ b/db/models/build.js
@@ -29,6 +29,8 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'buildId'
     }
     Build.belongsToMany(models.Theme, columnMapTheme);
+
+    Build.belongsTo(models.User, { foreignKey: 'userId' });
   };
   return Build;
 };

--- a/db/models/user.js
+++ b/db/models/user.js
@@ -23,6 +23,7 @@ module.exports = (sequelize, DataTypes) => {
     // associations can be defined here
     User.hasMany(models.Review, { foreignKey: 'userId' });
     User.hasMany(models.DisplayShelf, { foreignKey: 'userId' });
+    User.hasMany(models.Build, { foreignKey: 'userId' });
   };
   return User;
 };


### PR DESCRIPTION
This was done to allow us to make it possible for users to edit and delete the builds that they add to the database in the future